### PR TITLE
Added DispatchesOn attribute

### DIFF
--- a/src/Models/Attributes/DispatchesOn.php
+++ b/src/Models/Attributes/DispatchesOn.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Virtue\Models\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class DispatchesOn
+{
+    /**
+     * @param  class-string  $class
+     */
+    public function __construct(
+        public string $event,
+        public string $class,
+    ) {
+    }
+}

--- a/src/Models/Concerns/Virtue.php
+++ b/src/Models/Concerns/Virtue.php
@@ -18,7 +18,8 @@ trait Virtue
 {
     use HasRelations;
 
-    private ?Collection $classAttributes = null;
+    /** @var array<class-string,Collection>|null */
+    private static ?array $classAttributes = [];
 
     public function initializeVirtue(): void
     {
@@ -164,11 +165,12 @@ trait Virtue
 
     private function classAttributes(): Collection
     {
-        if (is_null($this->classAttributes)) {
+        $class = static::class;
+        if (! array_key_exists($class, self::$classAttributes) || is_null(self::$classAttributes[$class])) {
             $reflectionClass = new ReflectionClass(static::class);
-            $this->classAttributes = Collection::make($reflectionClass->getAttributes());
+            self::$classAttributes[$class] = Collection::make($reflectionClass->getAttributes());
         }
 
-        return $this->classAttributes;
+        return self::$classAttributes[$class];
     }
 }

--- a/tests/Datasets/UserCreated.php
+++ b/tests/Datasets/UserCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final class UserCreated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public UserEvents $user,
+    ) {
+    }
+}

--- a/tests/Datasets/UserDeleted.php
+++ b/tests/Datasets/UserDeleted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final class UserDeleted
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public UserEvents $user,
+    ) {
+    }
+}

--- a/tests/Datasets/UserEvents.php
+++ b/tests/Datasets/UserEvents.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Virtue\Models\Attributes\Database;
+use WendellAdriel\Virtue\Models\Attributes\DispatchesOn;
+use WendellAdriel\Virtue\Models\Attributes\Fillable;
+use WendellAdriel\Virtue\Models\Attributes\PrimaryKey;
+use WendellAdriel\Virtue\Models\Concerns\Virtue;
+
+#[Fillable([
+    'id',
+    'name',
+    'email',
+    'password',
+])]
+#[Database(table: 'users')]
+#[PrimaryKey(incrementing: false)]
+#[DispatchesOn(event: 'created', class: UserCreated::class)]
+#[DispatchesOn(event: 'updated', class: UserUpdated::class)]
+#[DispatchesOn(event: 'deleted', class: UserDeleted::class)]
+final class UserEvents extends Model
+{
+    use Virtue;
+}

--- a/tests/Datasets/UserUpdated.php
+++ b/tests/Datasets/UserUpdated.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final class UserUpdated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public UserEvents $user,
+    ) {
+    }
+}

--- a/tests/Feature/DispatchesOnTest.php
+++ b/tests/Feature/DispatchesOnTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Tests\Datasets\UserCreated;
+use Tests\Datasets\UserDeleted;
+use Tests\Datasets\UserEvents;
+use Tests\Datasets\UserUpdated;
+
+it('dispatches events', function () {
+    Event::fake();
+
+    $user = UserEvents::create([
+        'id' => 10,
+        'name' => fake()->name,
+        'email' => fake()->unique()->safeEmail,
+        'password' => 's3Cr3t@!!!',
+    ]);
+    Event::assertDispatched(UserCreated::class);
+
+    $user->name = fake()->name;
+    $user->save();
+    Event::assertDispatched(UserUpdated::class);
+
+    $user->delete();
+    Event::assertDispatched(UserDeleted::class);
+});


### PR DESCRIPTION
The DispatchesOn attribute allows to set the Model's events to be dispatched in the same way that the $dispatchesEvents property does.